### PR TITLE
Path is expanded inside vagrant machine

### DIFF
--- a/modules/phpmyadmin/manifests/init.pp
+++ b/modules/phpmyadmin/manifests/init.pp
@@ -20,7 +20,7 @@ class phpmyadmin (
 	}
 
 	# We need to make sure we handle custom paths otherwise WordPress will do a 404 for /phpmyadmin.
-	if ( '.' == $paths ) {
+	if ( '/vagrant' == $paths ) {
 			file { '/vagrant/phpmyadmin':
 				ensure => $link,
 				target => '/vagrant/extensions/phpmyadmin/phpmyadmin',


### PR DESCRIPTION
Hi guys,

I've run into a problem running this plugin against the latest version of Chassis on your main branch (https://github.com/Chassis/Chassis/commit/f349205fa6802fec3ea1a34267beb8ec546b1f6a).

I have a chassis instance that is using the default base directory setting of . and includes this plugin.

When I run this up from scratch I see the following error:

```bash
default: Notice: /Stage[main]/Phpmyadmin/File[/vagrant/extensions/phpmyadmin/phpmyadmin/config.inc.php]/ensure: defined content as '{md5}6164ff47a82739c53beae785a577041a'
default: Error: Could not set 'link' on ensure: No such file or directory @ dir_chdir - /chassis (file: /vagrant/extensions/phpmyadmin/modules/phpmyadmin/manifests/init.pp, line: 30)
default: Error: Could not set 'link' on ensure: No such file or directory @ dir_chdir - /chassis (file: /vagrant/extensions/phpmyadmin/modules/phpmyadmin/manifests/init.pp, line: 30)
default: Wrapped exception:
default: No such file or directory @ dir_chdir - /chassis
default: Error: /Stage[main]/Phpmyadmin/File[/chassis/phpmyadmin]/ensure: change from 'absent' to 'link' failed: Could not set 'link' on ensure: No such file or directory @ dir_chdir - /chassis (file: /vagrant/extensions/phpmyadmin/modules/phpmyadmin/manifests/init.pp, line: 30)
```

To see what was going on I popped the following debug code into https://github.com/Chassis/phpMyAdmin/blob/main/modules/phpmyadmin/manifests/init.pp:

```puppet
notify { "AJXB ${config[paths]}" :}
```

And got the following output when I brought the machine up:

```bash
default: Notice: AJXB {base => /vagrant, wp => /vagrant/wp, content => /vagrant/wp-content}
```

Notice that the base directory reported to the plugin is /vagrant, not .

Presumably this has something to do with https://github.com/Chassis/Chassis/blob/f349205fa6802fec3ea1a34267beb8ec546b1f6a/puppet/chassis.rb#L171:
```ruby
# Set up the paths as needed
config["mapped_paths"] = {}
base = config["paths"]["base"] = File.expand_path(config["paths"]["base"], @@dir)
base_path = Pathname.new base
```

To fix this issue I've just updated the condition in this plugin to use the expanded path.  Please could you consider including this fix into your codebase on the main branch?


Cheers,
Adam